### PR TITLE
removing metadata info from docstrings

### DIFF
--- a/py/core/bp_metadata_utils/blueprint_meta_data.py
+++ b/py/core/bp_metadata_utils/blueprint_meta_data.py
@@ -8,9 +8,9 @@ class BlueprintMetaData:
     """
     Class to represent blueprint metadata
     """
-    name: str
-    desc: str
-    author: str
+    # name: str
+    # desc: str
+    # author: str
     validations: List[Validation]
     
     def __json__(self):
@@ -21,8 +21,8 @@ class BlueprintMetaData:
               validations_json_list.append(validation.__json__())
 
         return {
-            'name': self.name,
-            'desc': self.desc,
-            'author': self.author,
+            # 'name': self.name,
+            # 'desc': self.desc,
+            # 'author': self.author,
             'validations': validations_json_list,
         }

--- a/py/core/bp_metadata_utils/customer_blueprint_repo.py
+++ b/py/core/bp_metadata_utils/customer_blueprint_repo.py
@@ -93,7 +93,7 @@ class CustomerBlueprintRepo(MultiplePoliciesPerFileRepo):
                 if not docstring:
                     continue
 
-                blueprint_docstring = BlueprintDocstring(docstring_raw=docstring)
+                # blueprint_docstring = BlueprintDocstring(docstring_raw=docstring)
                 validations_result = []
 
                 validations = self.parse_blueprint_file(blueprint_path)
@@ -101,9 +101,9 @@ class CustomerBlueprintRepo(MultiplePoliciesPerFileRepo):
                     validations_result.append(validation)
 
                 blueprint_meta_data = BlueprintMetaData(
-                    name=blueprint_docstring.name,
-                    desc=blueprint_docstring.desc,
-                    author=blueprint_docstring.author,
+                    # name=blueprint_docstring.name,
+                    # desc=blueprint_docstring.desc,
+                    # author=blueprint_docstring.author,
                     validations=validations_result
                 )
 


### PR DESCRIPTION
Docstrings can break the rendering of some blueprints, so we're disabling them for now