### PR TITLE
changing  stderr parser

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	DefaultConfigJson string = "config.json"
-	version           string = "0.0.4"
+	version           string = "0.0.5"
 )
 
 var rootCmd = &cobra.Command{

--- a/cli/internal/blueprints/python/python_runner.go
+++ b/cli/internal/blueprints/python/python_runner.go
@@ -39,9 +39,18 @@ func Run(runnerArgs runner.RunnerArgs, tempFilePath string) viewers.ResponseView
 	}
 
 	cmd := exec.Command("python", cmdArgs...)
-	stdOut, stdErr := cmd.CombinedOutput()
 
-	return viewers.ViewerFromRunnerOutput(tempFilePath, string(stdOut), stdErr)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	cmd.Run()
+
+	errStd := errors.New(stderr.String())
+
+	return viewers.ViewerFromRunnerOutput(tempFilePath, stdout.String(), errStd)
 }
 
 func GetPythonRunnerPackagePath() (string, error) {


### PR DESCRIPTION
The error object returned by CombinedOuputs function is in fact the exit status(1) and in our case it was preventing us from correctly parsing the stderr as it was also being combined with stdout. 