### PR TITLE
fixing the resource_type and config_id generation

### DIFF
--- a/py/core/services/tython_api_service.py
+++ b/py/core/services/tython_api_service.py
@@ -89,6 +89,7 @@ class TythonApiService:
 
         for finding in findings:
             if finding:
+                violation = finding.to_violation()
                 design_gaps.append(
                     {
                         "capabilityId": f"{config.org_id}.{capability_number}",
@@ -99,7 +100,7 @@ class TythonApiService:
                         "resourceType": finding.resource_metadata.resource_type,
                         "resourceGap": "",
                         "resourceImpact": "",
-                        "violations": [finding.to_violation().__json__()],
+                        "violations": [violation.__json__()],
                         "oak9Guidance": "",
                         "mappedIndustryFrameworks": []
                     }


### PR DESCRIPTION
This fixes the **resource_type** and **resource_id** for the finding object and also the **config_id** generation when using subsets of objects.

Note: With this change the target resource should be also passed to the Finding constructor:

```python
my_finding = Finding(
    resource=resource.usage_plan,
    resource_metadata=resource_metadata,
    finding_type=FindingType.DesignGap,
    desc="Naming convention is not inline with standards",
    config_id=Tools.get_config_id(resource, "usage_plan_name"),
    current_value=resource.usage_plan.usage_plan_name,
    rating=Severity.Critical,
    fix="Usage Plan name should have 15 or more characters"
)
```